### PR TITLE
Fix CI: Run both TOXENV=py3 and TOXENV=py3-numba

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: python
 os:
   - linux
-python:
-    - "3.6"
-env:
-  global:
-    - TOXENV=py
 notifications:
   email: false
 before_install:
@@ -36,7 +31,9 @@ script:
   - tox -- --cov diffeqpy
 jobs:
   include:
+    - env: TOXENV=py3
+      python: "3.8"
     - env: TOXENV=py3-numba
-      python: "3.6"
+      python: "3.8"
   allow_failures:
     - env: TOXENV=py3-numba


### PR DESCRIPTION
Before this patch, only TOXENV=py3-numba was run:
https://travis-ci.org/github/SciML/diffeqpy/builds/724373228

Since we ignore the test failures from Numba #48, there is no
meaningful CI anymore at the moment. This patch fixes the problem.

Also, let's use Python 3.8 in the test.