### PR TITLE
Stop mentioning Python 2.7 in setup.py and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,8 +472,8 @@ This is why declaring discontinuities can enhance the solver accuracy.
 Unit tests can be run by [`tox`](http://tox.readthedocs.io).
 
 ```sh
-tox                # test with Python 3.6 and 2.7
-tox -e py36        # test only with Python 3.6
+tox
+tox -e py3-numba   # test with Numba
 ```
 
 ### Troubleshooting

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,9 @@ setup(name='diffeqpy',
       classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Physics'
       ],


### PR DESCRIPTION
We already dropped Python 2 support
https://github.com/SciML/diffeqpy/pull/63
https://github.com/SciML/diffeqpy/pull/74/commits/2c2310938dc844a61e36d7c81ef9acdc440e3474

So, let's stop mentioning 2.7 in README.md and setup.py (so that PyPI shows the correct metadata).
