### PR TITLE
Add module to import OrdinaryDiffEq

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,17 @@ pip install numba
 
 ## General Flow
 
-Import and setup the solvers via the commands:
+Import and setup the solvers available in *DifferentialEquations.jl* via the commands:
 
 ```py
 from diffeqpy import de
 ```
-
+In case only the solvers available in *OrdinaryDiffEq.jl* are required then use the command:
+```py
+from diffeqpy import ode
+```
 The general flow for using the package is to follow exactly as would be done
-in Julia, except add `de.` in front.
+in Julia, except add `de.` or `ode.` in front. Note that `ode.` has lesser loading time and a smaller memory footprint compared to `de.`.
 Most of the commands will work without any modification. Thus
 [the DifferentialEquations.jl documentation](https://github.com/SciML/DifferentialEquations.jl)
 and the [DiffEqTutorials](https://github.com/SciML/DiffEqTutorials.jl)

--- a/diffeqpy/install.jl
+++ b/diffeqpy/install.jl
@@ -1,5 +1,6 @@
 using Pkg
 Pkg.add("DifferentialEquations")
+Pkg.add("OrdinaryDiffEq")
 Pkg.add("DiffEqBase")
 Pkg.add("PyCall")
 using DifferentialEquations

--- a/diffeqpy/ode.py
+++ b/diffeqpy/ode.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+from julia import Main
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+Main.include(os.path.join(script_dir, "setup.jl"))
+
+from julia import OrdinaryDiffEq
+sys.modules[__name__] = OrdinaryDiffEq   # mutate myself

--- a/diffeqpy/tests/test_ode_ordinarydiffeq.py
+++ b/diffeqpy/tests/test_ode_ordinarydiffeq.py
@@ -1,0 +1,53 @@
+from diffeqpy import ode
+import pytest
+
+
+def test_ode_sol_ordinarydiffeq():
+    numba = pytest.importorskip('numba')
+
+    def f(u,p,t):
+        return -u
+
+    u0 = 0.5
+    tspan = (0., 1.)
+    prob = ode.ODEProblem(f, u0, tspan)
+    sol = ode.solve(prob)
+    assert len(sol.t) < 10
+
+    numba_f = numba.jit(f)
+    prob = ode.ODEProblem(numba_f, u0, tspan)
+    sol2 = ode.solve(prob)
+    assert len(sol.t) == len(sol2.t)
+
+
+def test_lorenz_sol_ordinarydiffeq():
+    numba = pytest.importorskip('numba')
+
+    def f(u,p,t):
+        x, y, z = u
+        sigma, rho, beta = p
+        return [sigma * (y - x), x * (rho - z) - y, x * y - beta * z]
+
+    u0 = [1.0,0.0,0.0]
+    tspan = (0., 100.)
+    p = [10.0,28.0,8/3]
+    prob = ode.ODEProblem(f, u0, tspan, p)
+    sol = ode.solve(prob)
+
+    def f(du,u,p,t):
+        x, y, z = u
+        sigma, rho, beta = p
+        du[0] = sigma * (y - x)
+        du[1] = x * (rho - z) - y
+        du[2] = x * y - beta * z
+
+    u0 = [1.0,0.0,0.0]
+    tspan = (0., 100.)
+    p = [10.0,28.0,2.66]
+    prob = ode.ODEProblem(f, u0, tspan, p)
+    sol = ode.solve(prob)
+
+    numba_f = numba.jit(f)
+    prob = ode.ODEProblem(numba_f, u0, tspan, p)
+    sol2 = ode.solve(prob)
+    assert len(sol.t) == len(sol2.t)


### PR DESCRIPTION
This change will allow users of `diffeqpy `to use `OrdinaryDiffEq `which is a lighter weight package compared to `DifferentialEquations`. It will with decreasing loading time and sub-process memory consumption.

Usage: `from diffeqpy import ode`