### PR TITLE
Bundle ModelingToolkit and add de.jit

### DIFF
--- a/diffeqpy/__init__.py
+++ b/diffeqpy/__init__.py
@@ -37,10 +37,10 @@ def _ensure_installed(*kwargs):
         install(*kwargs)
 
 # TODO: upstream this function or an alternative into juliacall
-def load_julia_package(name):
+def load_julia_packages(names):
     # This is terrifying to many people. However, it seems SciML takes pragmatic approach.
     _ensure_installed()
 
     # Must be loaded after `_ensure_installed()`
     from juliacall import Main
-    return Main.seval(f"import Pkg; Pkg.activate(\"diffeqpy\", shared=true); import {name}; {name}")
+    return Main.seval(f"import Pkg; Pkg.activate(\"diffeqpy\", shared=true); import {names}; {names}")

--- a/diffeqpy/de.py
+++ b/diffeqpy/de.py
@@ -1,3 +1,6 @@
 import sys
-from . import load_julia_package
-sys.modules[__name__] = load_julia_package("DifferentialEquations") # mutate myself
+from . import load_julia_packages
+de, _ = load_julia_packages("DifferentialEquations, ModelingToolkit")
+from juliacall import Main
+de.jit = Main.seval("jit(x) = typeof(x).name.wrapper(ModelingToolkit.modelingtoolkitize(x), x.u0, x.tspan, x.p)") # kinda hackey
+sys.modules[__name__] = de # mutate myself

--- a/diffeqpy/install.jl
+++ b/diffeqpy/install.jl
@@ -1,4 +1,4 @@
 using Pkg
 Pkg.activate("diffeqpy", shared=true)
-Pkg.add(["DifferentialEquations", "OrdinaryDiffEq", "PythonCall"])
-using DifferentialEquations, OrdinaryDiffEq, PythonCall # Precompile
+Pkg.add(["DifferentialEquations", "ModelingToolkit", "OrdinaryDiffEq","PythonCall"])
+using DifferentialEquations, ModelingToolkit, OrdinaryDiffEq, PythonCall # Precompile

--- a/diffeqpy/ode.py
+++ b/diffeqpy/ode.py
@@ -1,3 +1,3 @@
 import sys
-from . import load_julia_package
-sys.modules[__name__] = load_julia_package("OrdinaryDiffEq") # mutate myself
+from . import load_julia_packages
+sys.modules[__name__] = load_julia_packages("OrdinaryDiffEq") # mutate myself


### PR DESCRIPTION
This PR contains a feature addition: bundle ModelingToolkit and add de.jit
And a documentation change: update readme to switch from partially broken instructions for how to use numba to partially broken instructions for how to use de.jit

Notably, de.jit fails on `DAEProblem` with `no method matching matching modelingtoolkitize(::SciMLBase.DAEProblem{...})`. 
This PR does not yet adjust tests, which still use `numba` and do not use `de.jit`. It's probably good to keep testing `numba` interop and add `de.jit` testing on top.