### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ def prob_func(prob,i,rep):
   return de.remake(prob,u0=[random.uniform(0, 1)*u0[i] for i in range(0,3)],
             p=[random.uniform(0, 1)*p[i] for i in range(0,3)])
 
-ensembleprob = de.EnsembleProblem(fast_prob, safetycopy=False)
+ensembleprob = de.EnsembleProblem(fast_prob, prob_func=prob_func, safetycopy=False)
 ```
 
 Now we solve the ensemble in serial:

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ initial conditions and parameters:
 ```py
 import random
 def prob_func(prob,i,rep):
-  de.remake(prob,u0=[random.uniform(0, 1)*u0[i] for i in range(0,3)],
+  return de.remake(prob,u0=[random.uniform(0, 1)*u0[i] for i in range(0,3)],
             p=[random.uniform(0, 1)*p[i] for i in range(0,3)])
 
 ensembleprob = de.EnsembleProblem(fast_prob, safetycopy=False)


### PR DESCRIPTION
I tested this (concatenation of code blocks in readme after this PR) locally and it works:
```py
from diffeqpy import de

def f(u,p,t):
    x, y, z = u
    sigma, rho, beta = p
    return [sigma * (y - x), x * (rho - z) - y, x * y - beta * z]

u0 = [1.0,0.0,0.0]
tspan = (0., 100.)
p = [10.0,28.0,8/3]
prob = de.ODEProblem(f, u0, tspan, p)
fast_prob = de.jit32(prob)
sol = de.solve(fast_prob,saveat=0.01)

import random
def prob_func(prob,i,rep):
  return de.remake(prob,u0=[random.uniform(0, 1)*u0[i] for i in range(0,3)],
            p=[random.uniform(0, 1)*p[i] for i in range(0,3)])

ensembleprob = de.EnsembleProblem(fast_prob, prob_func = prob_func, safetycopy=False)
sol = de.solve(ensembleprob,de.Tsit5(),de.EnsembleSerial(),trajectories=100,saveat=0.01)

sol.u[0]
sol.u[1]
```

Fixes the issue in the OP of https://github.com/SciML/diffeqpy/issues/123 using the approach recommended by @jodemaey. Does not address @jodemaey's followup concerns about GPU usage.