### PR TITLE
Remove version restriction

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install Julia using jill
         run: |
           python -m pip install --upgrade jill
-          python -c "from jill.install import install_julia; install_julia(version='1.10', confirm=True)"
+          python -c "from jill.install import install_julia; install_julia(confirm=True)"
       - name: Run test
         run: python -m tox -- --cov=diffeqpy -s
         env:

--- a/diffeqpy/__init__.py
+++ b/diffeqpy/__init__.py
@@ -12,7 +12,7 @@ def _find_julia():
 def _ensure_julia_installed():
     if not _find_julia():
         print("No Julia version found. Installing Julia.")
-        install_julia(version="1.10")
+        install_julia()
         if not _find_julia():
             raise RuntimeError(
                 "Julia installed with jill but `julia` binary cannot be found in the path"


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Since issue #144 is closed, there is no longer a need to restrict the version of Julia to be installed.
