### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-14
+          - macos-latest
           # Disabling Windows tests as it's known to not work:
           # https://github.com/SciML/diffeqpy/pull/86#issuecomment-1011675735
           # - windows-latest
-        python-version: ['3.8', '3.12']
+        python-version: ['3.8', '3.13']
       fail-fast: false
     name: Test ${{ matrix.os }} ${{ matrix.architecture }}
       Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name='diffeqpy',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Scientific/Engineering :: Physics'
       ],


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Since `numba` [v0.61](https://github.com/numba/numba/releases/tag/0.61.0) is available, diffeqpy can  be tested with Python 3.13.
