### PR TITLE
fix: correct open encoding

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 def readme():
-    with open('README.md', encoding="utf8") as f:
+    with open('README.md', encoding="utf-8") as f:
         return f.read()
 
 setup(name='diffeqpy',


### PR DESCRIPTION
Using "utf8" instead of "utf-8" to indicate the encoding  seems to create issues on Windows, making it unable to install the package.

Now, the python documentation of [open](https://docs.python.org/3/library/functions.html#open) uses says that you can use any encoding from [here](https://docs.python.org/3/library/functions.html#open), which states that `'utf-8' is a valid alias for the 'utf_8' codec`.
To be fair, "utf8" should work too, but I assume this is not properly supported on Windows.

In any case, all the official examples I could find from the python documentation use "utf-8" ([example](https://docs.python.org/3/howto/unicode.html#reading-and-writing-unicode-data)), so that is probably the safest option.

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
### Additional information

Tested on
- Windows 10
- Python 3.10 (conda environment)
