### PR TITLE
Make jill an optional dependency with lazy import

### DIFF
--- a/diffeqpy/__init__.py
+++ b/diffeqpy/__init__.py
@@ -1,5 +1,4 @@
 import shutil
-from jill.install import install_julia
 
 # juliacall must be loaded after `_ensure_julia_installed()` is run,
 # so this import is in `load_julia_packages()`
@@ -12,6 +11,13 @@ def _find_julia():
 def _ensure_julia_installed():
     if not _find_julia():
         print("No Julia version found. Installing Julia.")
+        try:
+            from jill.install import install_julia
+        except ImportError:
+            raise RuntimeError(
+                "Julia is not installed and the 'jill' package is not available. "
+                "Please install Julia manually or install jill: pip install jill"
+            )
         install_julia()
         if not _find_julia():
             raise RuntimeError(
@@ -61,6 +67,13 @@ def install(*, confirm=False):
     julia = _find_julia()
     if not julia:
         print("No Julia version found. Installing Julia.")
+        try:
+            from jill.install import install_julia
+        except ImportError:
+            raise RuntimeError(
+                "Julia is not installed and the 'jill' package is not available. "
+                "Please install Julia manually or install jill: pip install jill"
+            )
         install_julia(confirm=confirm)
         julia = _find_julia()
         if not julia:


### PR DESCRIPTION
## Summary

This PR addresses the implementation approach in #161 with a cleaner solution using lazy imports instead of dummy functions.

## Problem with PR #161's approach

PR #161 defines a dummy function at import time:
```python
try:
    from jill.install import install_julia
except ModuleNotFoundError:
    def install_julia():
        raise RuntimeError("Could not install Julia as the Jill module was not found.")
```

This approach:
- Creates a confusing placeholder function that only exists to raise an error
- Delays error detection until the function is actually called
- Makes the code harder to understand

## Better Solution: Lazy Import

Move the jill import to where it's actually used:

```python
def _ensure_julia_installed():
    if not _find_julia():
        print("No Julia version found. Installing Julia.")
        try:
            from jill.install import install_julia
        except ImportError:
            raise RuntimeError(
                "Julia is not installed and the 'jill' package is not available. "
                "Please install Julia manually or install jill: pip install jill"
            )
        install_julia()
        # ...
```

## Benefits

1. **Cleaner code**: No dummy functions that just raise errors
2. **Better error messages**: Clear, immediate error messages when there's a problem
3. **Lazy loading**: Only imports jill when Julia installation is actually needed
4. **Same functionality**: Jill remains a default dependency, no change in user experience

## Changes

- `diffeqpy/__init__.py`: 
  - Remove top-level `from jill.install import install_julia`
  - Add lazy import with proper error handling in `_ensure_julia_installed()` and `install()` functions
- `setup.py`: No changes (jill remains a required dependency)

## Testing

- Syntax validation passes
- Same functionality as before, just cleaner implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)