### PR TITLE
Release 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='diffeqpy',
-      version='2.5.4',
+      version='2.6.0',
       description='Solving Differential Equations in Python',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary

Bump version to 2.6.0 for release to PyPI.

### Changes since 2.5.4

- **Make jill an optional dependency with lazy import** (PR #162) - Important fix for users without jill installed
- Drop Python 3.8/3.9 support, require Python 3.10+
- Update juliacall requirement to >=0.9.28
- Add Python 3.14 support
- CI improvements

Fixes #164

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)