### PR TITLE
Release version 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='diffeqpy',
-      version='2.5.5',
+      version='2.6.0',
       description='Solving Differential Equations in Python',
       long_description=readme(),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary

Bump version to 2.6.0 for release to PyPI.

### Changes since 2.5.5

- **Add Julia package manifest for automatic dependency management** (#176) — adds `diffeqpy/juliapkg.json` declaring the documented solver stack (DifferentialEquations, OrdinaryDiffEq, OrdinaryDiffEqDefault, StochasticDiffEq, DelayDiffEq, Sundials, DiffEqCallbacks, ModelingToolkit) with compatible version ranges, so juliacall installs them into its ABI-matched managed project at import time. Fixes the `pip install diffeqpy` segfault on clean environments reported in #175.
- **Build merged `_diffeqpy_de` module so `de.<name>` works post-v8** (#177, merged into #176) — DifferentialEquations.jl v8 trimmed its re-exports to SciMLBase + OrdinaryDiffEq, so the previous `de = loaded[0]` shape lost access to MethodOfSteps, IDA, CVODE_BDF, SOSRI, etc. The new shape builds a fresh module that `using`s the full documented stack.
- **DDE test uses explicit `MethodOfSteps(Tsit5())`** — works around an open upstream regression in SciML/OrdinaryDiffEq.jl's DDE default-algorithm selector that causes `Cannot convert Rosenbrock23Cache{...}` MethodErrors on the v7-coupled stack (#172).

### Release process notes

This PR can be merged once #176 lands on master so the release contains the changes above. After merge, tag `v2.6.0` on the merge commit; PyPI upload is manual (`python -m build && python -m twine upload dist/*`) — there's no automated release workflow.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)