### PR TITLE
Auto-publish to PyPI on GitHub release (Trusted Publisher)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/diffeqpy
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` that fires on `release: published`
- Builds sdist + wheel with `python -m build`
- Uploads via `pypa/gh-action-pypi-publish` using OIDC — no PyPI token stored in repo secrets

After this lands, the release flow is: bump version → tag → `gh release create` → workflow uploads to PyPI automatically.

## One-time PyPI setup required before this works

On https://pypi.org/manage/project/diffeqpy/settings/publishing/ add a Trusted Publisher with:

- **Owner:** `SciML`
- **Repository:** `diffeqpy`
- **Workflow filename:** `release.yml`
- **Environment:** `pypi`

(The `pypi` environment is declared in the workflow's `environment:` block. Optionally create a matching GitHub Environment under repo Settings → Environments for protection rules; not required for publishing to work.)

## Test plan

- [ ] PyPI Trusted Publisher registered as above
- [ ] After merge, cut a patch release (e.g. v2.6.1) and confirm the workflow run uploads the artifact
- [ ] Verify https://pypi.org/project/diffeqpy/ shows the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)