### PR TITLE
Keep Julia available across Linux CI steps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,10 +34,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade tox
-      - name: Install Julia using jill
-        run: |
-          python -m pip install --upgrade jill
-          python -c "from jill.install import install_julia; install_julia(confirm=True)"
+      - name: Setup Julia
+        uses: julia-actions/setup-julia@v3
+        with:
+          version: '1.10'
+      - name: Verify Julia is available
+        run: julia --version
       - name: Run test
         run: python -m tox -- --cov=diffeqpy -s
         env:


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Use julia-actions/setup-julia for the test matrix instead of installing Julia through JILL inside one shell step.

JILL installs the binary under ~/.local/bin and updates shell startup files, but the following GitHub Actions step does not inherit that PATH update. As a result, diffeqpy.install() cannot find Julia, attempts a second interactive JILL installation, and exits on EOF. setup-julia writes Julia to GitHub Actions' cross-step PATH.

The workflow pins Julia 1.10, which is within juliacall 0.9.35's supported range, and verifies availability in a separate step before tox.

## Local verification

- Reproduced the original hidden-PATH failure: diffeqpy.install() attempted interactive JILL and exited on EOF
- Python 3.10 / tox 4 workflow-equivalent run: 5 tests passed; process exited successfully in 187.45 seconds
- A separate clean integration run also completed successfully
- Runic was run over the repository; it found unrelated pre-existing formatting differences in five deprecated Julia installer scripts, so those were left out of this focused workflow PR. The PR's Runic Suggestions check is green.

Python 3.13 is not installed on this host, so that matrix lane remains CI-only.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.